### PR TITLE
Make tb4 sim work with namespaced simulations

### DIFF
--- a/nav2_minimal_tb4_description/CMakeLists.txt
+++ b/nav2_minimal_tb4_description/CMakeLists.txt
@@ -6,6 +6,8 @@ find_package(ament_cmake REQUIRED)
 find_package(urdf REQUIRED)
 find_package(xacro REQUIRED)
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/tb4_description.dsv.in")
+
 install(
   DIRECTORY launch meshes urdf rviz
   DESTINATION share/${PROJECT_NAME}

--- a/nav2_minimal_tb4_description/hooks/tb4_description.dsv.in
+++ b/nav2_minimal_tb4_description/hooks/tb4_description.dsv.in
@@ -1,0 +1,1 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/

--- a/nav2_minimal_tb4_sim/configs/tb4_bridge.yaml
+++ b/nav2_minimal_tb4_sim/configs/tb4_bridge.yaml
@@ -1,5 +1,5 @@
 # replace clock_bridge
-- ros_topic_name: "clock"
+- ros_topic_name: "/clock"
   gz_topic_name: "/clock"
   ros_type_name: "rosgraph_msgs/msg/Clock"
   gz_type_name: "gz.msgs.Clock"

--- a/nav2_minimal_tb4_sim/launch/spawn_tb4.launch.py
+++ b/nav2_minimal_tb4_sim/launch/spawn_tb4.launch.py
@@ -22,7 +22,7 @@ from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 
-from launch_ros.actions import Node, PushRosNamespace
+from launch_ros.actions import Node
 
 
 def generate_launch_description():
@@ -72,6 +72,7 @@ def generate_launch_description():
         package='ros_gz_bridge',
         executable='parameter_bridge',
         name='bridge_ros_gz',
+        namespace=namespace,
         parameters=[
             {
                 'config_file': os.path.join(
@@ -87,6 +88,7 @@ def generate_launch_description():
         package='ros_gz_image',
         executable='image_bridge',
         name='bridge_gz_ros_camera_image',
+        namespace=namespace,
         output='screen',
         parameters=[{
             'use_sim_time': use_sim_time,
@@ -97,6 +99,7 @@ def generate_launch_description():
         package='ros_gz_image',
         executable='image_bridge',
         name='bridge_gz_ros_camera_depth',
+        namespace=namespace,
         output='screen',
         parameters=[{
             'use_sim_time': use_sim_time,
@@ -107,6 +110,7 @@ def generate_launch_description():
         condition=IfCondition(use_simulator),
         package='ros_gz_sim',
         executable='create',
+        namespace=namespace,
         output='screen',
         arguments=[
             '-name', robot_name,
@@ -124,8 +128,6 @@ def generate_launch_description():
     # ld.add_action(declare_robot_sdf_cmd)
     ld.add_action(declare_use_simulator_cmd)
     ld.add_action(declare_use_sim_time_cmd)
-
-    ld.add_action(PushRosNamespace(namespace))
 
     ld.add_action(bridge)
     ld.add_action(camera_bridge_image)

--- a/nav2_minimal_tb4_sim/launch/spawn_tb4.launch.py
+++ b/nav2_minimal_tb4_sim/launch/spawn_tb4.launch.py
@@ -14,14 +14,11 @@
 # limitations under the License.
 
 import os
-from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import AppendEnvironmentVariable
 from launch.actions import DeclareLaunchArgument
-from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node, PushRosNamespace

--- a/nav2_minimal_tb4_sim/launch/spawn_tb4.launch.py
+++ b/nav2_minimal_tb4_sim/launch/spawn_tb4.launch.py
@@ -19,6 +19,7 @@ from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node, PushRosNamespace
@@ -30,6 +31,7 @@ def generate_launch_description():
 
     use_sim_time = LaunchConfiguration('use_sim_time')
     namespace = LaunchConfiguration('namespace')
+    use_simulator = LaunchConfiguration('use_simulator')
     robot_name = LaunchConfiguration('robot_name')
     # robot_sdf = LaunchConfiguration('robot_sdf')
     pose = {'x': LaunchConfiguration('x_pose', default='-8.00'),
@@ -44,6 +46,11 @@ def generate_launch_description():
         'namespace',
         default_value='',
         description='Top-level namespace')
+
+    declare_use_simulator_cmd = DeclareLaunchArgument(
+        'use_simulator',
+        default_value='True',
+        description='Whether to start the simulator')
 
     declare_use_sim_time_cmd = DeclareLaunchArgument(
         'use_sim_time',
@@ -97,6 +104,7 @@ def generate_launch_description():
         arguments=['/rgbd_camera/depth_image'])
 
     spawn_model = Node(
+        condition=IfCondition(use_simulator),
         package='ros_gz_sim',
         executable='create',
         output='screen',
@@ -114,6 +122,7 @@ def generate_launch_description():
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_robot_name_cmd)
     # ld.add_action(declare_robot_sdf_cmd)
+    ld.add_action(declare_use_simulator_cmd)
     ld.add_action(declare_use_sim_time_cmd)
 
     ld.add_action(PushRosNamespace(namespace))

--- a/nav2_minimal_tb4_sim/launch/spawn_tb4.launch.py
+++ b/nav2_minimal_tb4_sim/launch/spawn_tb4.launch.py
@@ -33,7 +33,6 @@ def generate_launch_description():
 
     use_sim_time = LaunchConfiguration('use_sim_time')
     namespace = LaunchConfiguration('namespace')
-    use_simulator = LaunchConfiguration('use_simulator')
     robot_name = LaunchConfiguration('robot_name')
     # robot_sdf = LaunchConfiguration('robot_sdf')
     pose = {'x': LaunchConfiguration('x_pose', default='-8.00'),
@@ -48,11 +47,6 @@ def generate_launch_description():
         'namespace',
         default_value='',
         description='Top-level namespace')
-
-    declare_use_simulator_cmd = DeclareLaunchArgument(
-        'use_simulator',
-        default_value='True',
-        description='Whether to start the simulator')
 
     declare_use_sim_time_cmd = DeclareLaunchArgument(
         'use_sim_time',
@@ -123,7 +117,6 @@ def generate_launch_description():
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_robot_name_cmd)
     # ld.add_action(declare_robot_sdf_cmd)
-    ld.add_action(declare_use_simulator_cmd)
     ld.add_action(declare_use_sim_time_cmd)
 
     ld.add_action(PushRosNamespace(namespace))

--- a/nav2_minimal_tb4_sim/launch/spawn_tb4.launch.py
+++ b/nav2_minimal_tb4_sim/launch/spawn_tb4.launch.py
@@ -27,7 +27,6 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     sim_dir = get_package_share_directory('nav2_minimal_tb4_sim')
-    # desc_dir = get_package_share_directory('nav2_minimal_tb4_description')
 
     use_sim_time = LaunchConfiguration('use_sim_time')
     namespace = LaunchConfiguration('namespace')
@@ -62,11 +61,6 @@ def generate_launch_description():
         'robot_name',
         default_value='turtlebot4',
         description='name of the robot')
-
-    # declare_robot_sdf_cmd = DeclareLaunchArgument(
-    #     'robot_sdf',
-    #     default_value=os.path.join(desc_dir, 'urdf', 'standard', 'turtlebot4.urdf.xacro'),
-    #     description='Full path to robot sdf file to spawn the robot in gazebo')
 
     bridge = Node(
         package='ros_gz_bridge',
@@ -115,7 +109,6 @@ def generate_launch_description():
         arguments=[
             '-name', robot_name,
             '-topic', 'robot_description',
-            # '-file', Command(['xacro', ' ', robot_sdf]), # TODO SDF file is unhappy, not sure why
             '-x', pose['x'], '-y', pose['y'], '-z', pose['z'],
             '-R', pose['R'], '-P', pose['P'], '-Y', pose['Y']],
         parameters=[{'use_sim_time': use_sim_time}]
@@ -125,7 +118,6 @@ def generate_launch_description():
     ld = LaunchDescription()
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_robot_name_cmd)
-    # ld.add_action(declare_robot_sdf_cmd)
     ld.add_action(declare_use_simulator_cmd)
     ld.add_action(declare_use_sim_time_cmd)
 


### PR DESCRIPTION
Hello there!

I was trying to get a namespaced simulation to work for interoperability with a MoveIt2 arm that I was getting on and I noticed that the namespacing doesn't work super well.

This PR helps in that direction, note that rviz will still not quite work since it relies on a config file that is not namespaced, but at least the simulation can run.

## Test it!

On latest main / rolling with nav2 and this package built from source:

```
ros2 launch nav2_bringup tb4_simulation_launch.py use_namespace:=true namespace:=/tb4 headless:=0
```

Without the PR you will see bunch of errors because the namespacing is _not_ applied to the topic that this launch file passes to the `create` node and you will get a continuous stream of this message:

```
[create-5] [INFO] [1726828557.189342324] [ros_gz_sim]: Waiting messages on topic [robot_description].
```

Also `ros_gz_sim create` does _not_ seem to have a `robot_namespace` parameter, and `-entity` is actually `-name`:

```
lucadv@noble:~/ionic_ws$ ros2 run ros_gz_sim create --help
create: Usage: create -world [arg] [-file FILE] [-param PARAM] [-topic TOPIC]
                       [-string STRING] [-name NAME] [-allow_renaming RENAMING] [-x X] [-y Y] [-z Z]
                       [-R ROLL] [-P PITCH] [-Y YAW]

[...]

  Flags from /usr/local/google/home/lucadv/ionic_ws/src/ros2/ros_ign/ros_gz_sim/src/create.cpp:
    -P (Pitch component of initial orientation, in radians.) type: double
      default: 0
    -R (Roll component of initial orientation, in radians.) type: double
      default: 0
    -Y (Yaw component of initial orientation, in radians.) type: double
      default: 0
    -allow_renaming (Rename entity if name already used.) type: bool
      default: false
    -file (Load XML from a file.) type: string default: ""
    -name (Name for spawned entity.) type: string default: ""
    -param (Load XML from a ROS param.) type: string default: ""
    -string (Load XML from a string.) type: string default: ""
    -topic (Load XML from a ROS string publisher.) type: string default: ""
    -world (World name.) type: string default: ""
    -x (X component of initial position, in meters.) type: double default: 0
    -y (Y component of initial position, in meters.) type: double default: 0
    -z (Z component of initial position, in meters.) type: double default: 0
```

With this PR, you should see that the demo works and you can set a start pose and get the robot to navigate, now this still generates a lot of errors, the costmaps are not displayed, but it's a step forward