### PR TITLE
Cannot launch when there's a [space] to the ros_ws path

### DIFF
--- a/nav2_minimal_tb4_sim/launch/simulation.launch.py
+++ b/nav2_minimal_tb4_sim/launch/simulation.launch.py
@@ -125,7 +125,7 @@ def generate_launch_description():
 
     declare_robot_sdf_cmd = DeclareLaunchArgument(
         'robot_sdf',
-        default_value=os.path.join(desc_dir, 'urdf', 'standard', 'turtlebot4.urdf.xacro'),
+        default_value=f'"{os.path.join(desc_dir, 'urdf', 'standard', 'turtlebot4.urdf.xacro')}"',
         description='Full path to robot sdf file to spawn the robot in gazebo',
     )
 


### PR DESCRIPTION
If there is a [space] in the path to the `ros_ws`, the xacro command will throw an error.
This is fixed with this commit.