### PR TITLE
Feat/Add PointCloud2 sensor

### DIFF
--- a/nav2_minimal_tb4_description/urdf/icreate/common_properties.urdf.xacro
+++ b/nav2_minimal_tb4_description/urdf/icreate/common_properties.urdf.xacro
@@ -48,8 +48,9 @@
   </xacro:macro>
 
   <xacro:macro name="ray_sensor" 
-    params="sensor_name gazebo update_rate visualize 
+    params="sensor_name use_vertical_rays:=^|false gazebo update_rate visualize 
             h_samples h_res h_min_angle h_max_angle
+            v_samples:=^|0 v_res:=^|0 v_min_angle:=^|0 v_max_angle:=^|0
             r_min r_max r_res *plugin">
     <sensor name="${sensor_name}" type="gpu_lidar">
       <update_rate>${update_rate}</update_rate>
@@ -65,6 +66,14 @@
             <min_angle>${h_min_angle}</min_angle>
             <max_angle>${h_max_angle}</max_angle>
           </horizontal>
+          <xacro:if value="${use_vertical_rays}">
+            <vertical>
+              <samples>${v_samples}</samples>
+              <resolution>${v_res}</resolution>
+              <min_angle>${v_min_angle}</min_angle>
+              <max_angle>${v_max_angle}</max_angle>
+            </vertical>
+          </xacro:if>
         </scan>
         <range>
           <min>${r_min}</min>

--- a/nav2_minimal_tb4_description/urdf/sensors/velodyne.urdf.xacro
+++ b/nav2_minimal_tb4_description/urdf/sensors/velodyne.urdf.xacro
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+
+<xacro:macro name="velodyne" params="name parent_link gazebo *origin">
+  <xacro:include filename="$(find nav2_minimal_tb4_description)/urdf/icreate/common_properties.urdf.xacro"/>
+
+  <xacro:property name="mass"       value="0.17"/>
+  <xacro:property name="length_x"   value="${7.1*cm2m}" />
+  <xacro:property name="length_y"   value="${10*cm2m}" />
+  <xacro:property name="length_z"   value="${6*cm2m}" />
+
+  <xacro:property name="collision_x_offset"       value="${0*cm2m}" />
+  <xacro:property name="collision_y_offset"       value="${1.3*cm2m}" />
+  <xacro:property name="collision_z_offset"       value="${-1.9*cm2m}" />
+
+  <joint name="${name}_joint" type="fixed">
+    <parent link="${parent_link}"/>
+    <child link="${name}_link"/>
+    <xacro:insert_block name="origin"/>
+  </joint>
+
+  <link name="${name}_link">
+    <visual>
+      <geometry>
+        <mesh filename="package://nav2_minimal_tb4_description/meshes/rplidar.dae" scale="1 1 1" />
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="${collision_x_offset} ${collision_y_offset} ${collision_z_offset}"/>
+      <geometry>
+        <box size="${length_x} ${length_y} ${length_z}"/>
+      </geometry>
+    </collision>
+    <xacro:inertial_cuboid mass="0.17" x="${length_x}" y="${length_y}" z="${length_z}"/>
+  </link>
+
+  <gazebo reference="${name}_link">
+    <xacro:ray_sensor sensor_name="${name}" use_vertical_rays="true" gazebo="${gazebo}" 
+                  update_rate="10.0" visualize="true" 
+                  h_samples="360" h_res="1.0" h_min_angle="0.000" h_max_angle="6.280000" 
+                  v_samples="180" v_res="0.2" v_min_angle="-0.03" v_max_angle="0.215"
+                  r_min="0.164" r_max="20.0" r_res="0.01">
+                  <plugin name="dummy" filename="dummyfile"></plugin>
+    </xacro:ray_sensor>
+    <xacro:material_darkgray/>
+  </gazebo>
+
+  <gazebo reference="${name}_joint">
+    <preserveFixedJoint>true</preserveFixedJoint>
+  </gazebo>
+
+</xacro:macro>
+</robot>

--- a/nav2_minimal_tb4_description/urdf/standard/turtlebot4.urdf.xacro
+++ b/nav2_minimal_tb4_description/urdf/standard/turtlebot4.urdf.xacro
@@ -3,6 +3,7 @@
   <!-- Base create3 model -->
   <xacro:include filename="$(find nav2_minimal_tb4_description)/urdf/icreate/create3.urdf.xacro" />
   <xacro:include filename="$(find nav2_minimal_tb4_description)/urdf/sensors/rplidar.urdf.xacro" />
+  <xacro:include filename="$(find nav2_minimal_tb4_description)/urdf/sensors/velodyne.urdf.xacro" />
   <xacro:include filename="$(find nav2_minimal_tb4_description)/urdf/sensors/oakd.urdf.xacro" />
   <xacro:include filename="$(find nav2_minimal_tb4_description)/urdf/sensors/camera_bracket.urdf.xacro" />
   <xacro:include filename="$(find nav2_minimal_tb4_description)/urdf/standard/tower_standoff.urdf.xacro" />
@@ -130,10 +131,21 @@
   </xacro:tower_sensor_plate>
 
   <!-- Turtlebot4 sensor definitions -->
-  <xacro:rplidar name="rplidar" parent_link="shell_link" gazebo="$(arg gazebo)">
-    <origin xyz="${rplidar_x_offset} ${rplidar_y_offset} ${rplidar_z_offset}"
-            rpy="0 0 ${pi/2}"/>
-  </xacro:rplidar>
+  <xacro:arg name="use_3d_lidar" default="false" />
+
+  <xacro:unless value="$(arg use_3d_lidar)">
+    <xacro:rplidar name="rplidar" parent_link="shell_link" gazebo="$(arg gazebo)">
+      <origin xyz="${rplidar_x_offset} ${rplidar_y_offset} ${rplidar_z_offset}"
+              rpy="0 0 ${pi/2}"/>
+    </xacro:rplidar>
+  </xacro:unless>
+
+  <xacro:if value="$(arg use_3d_lidar)">
+    <xacro:velodyne name="velodyne" parent_link="shell_link" gazebo="$(arg gazebo)">
+      <origin xyz="${rplidar_x_offset} ${rplidar_y_offset} ${rplidar_z_offset}"
+              rpy="0 0 ${pi/2}"/>
+    </xacro:velodyne>
+  </xacro:if>
 
   <xacro:camera_bracket name="oakd_camera_bracket">
     <origin xyz="${camera_mount_x_offset} ${camera_mount_y_offset} ${camera_mount_z_offset}"/>

--- a/nav2_minimal_tb4_sim/launch/simulation.launch.py
+++ b/nav2_minimal_tb4_sim/launch/simulation.launch.py
@@ -54,6 +54,7 @@ def generate_launch_description():
     use_simulator = LaunchConfiguration('use_simulator')
     use_robot_state_pub = LaunchConfiguration('use_robot_state_pub')
     headless = LaunchConfiguration('headless')
+    use_3dlidar = LaunchConfiguration('use_3dlidar')
     world = LaunchConfiguration('world')
     pose = {
         'x': LaunchConfiguration('x_pose', default='-8.00'),
@@ -113,6 +114,12 @@ def generate_launch_description():
         'headless', default_value='False', description='Whether to execute gzclient)'
     )
 
+    declare_use_3dlidar_cmd = DeclareLaunchArgument(
+        'use_3dlidar',
+        default_value='False',
+        description='Whether to use 3D Lidar and publish pointcloud2'
+    )
+
     declare_world_cmd = DeclareLaunchArgument(
         'world',
         default_value=os.path.join(sim_dir, 'worlds', 'depot.sdf'),
@@ -138,7 +145,9 @@ def generate_launch_description():
         output='screen',
         parameters=[
             {'use_sim_time': use_sim_time,
-             'robot_description': Command(['xacro', ' ', robot_sdf])}
+             'robot_description': Command(
+                ['xacro', ' ', 'use_3d_lidar:=', use_3dlidar, ' ', robot_sdf]
+                )}
         ],
         remappings=remappings,
     )
@@ -196,6 +205,7 @@ def generate_launch_description():
         launch_arguments={'namespace': namespace,
                           'use_simulator': use_simulator,
                           'use_sim_time': use_sim_time,
+                          'use_3dlidar': use_3dlidar,
                           'robot_name': robot_name,
                           'robot_sdf': robot_sdf,
                           'x_pose': pose['x'],
@@ -217,6 +227,7 @@ def generate_launch_description():
     ld.add_action(declare_use_simulator_cmd)
     ld.add_action(declare_use_robot_state_pub_cmd)
     ld.add_action(declare_simulator_cmd)
+    ld.add_action(declare_use_3dlidar_cmd)
     ld.add_action(declare_world_cmd)
     ld.add_action(declare_robot_name_cmd)
     ld.add_action(declare_robot_sdf_cmd)


### PR DESCRIPTION
Add option for publishing PointCloud2 
- Used [ros_gz_bridge](https://github.com/gazebosim/ros_gz)
- Couldn't use [ros_gz_point_cloud](https://github.com/gazebosim/ros_gz/tree/ros2/ros_gz_point_cloud) because of
 https://github.com/gazebosim/ros_gz/issues/40

Could've just add it directly to the bridge config file [tb4_bridge.yaml](https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation/blob/afcaace36273cea2b06e76a0d0e3bc6a038a66c8/nav2_minimal_tb4_sim/configs/tb4_bridge.yaml), but it's totally separated so user can choose whether to publish PointCloud2  or not "Default" keeping the package minimal as possible
```bash
ros2 launch nav2_minimal_tb4_sim simulation.launch.py use_3dlidar:=True
```