### PR TITLE
Fixed issue with tilted Lidar

### DIFF
--- a/nav2_minimal_tb3_sim/urdf/gz_waffle.sdf.xacro
+++ b/nav2_minimal_tb3_sim/urdf/gz_waffle.sdf.xacro
@@ -9,7 +9,7 @@
 
       <link name="base_link">
 
-        <inertial>
+        <inertial> 
           <pose>-0.064 0 0.048 0 0 0</pose>
           <inertia>
             <ixx>0.001</ixx>

--- a/nav2_minimal_tb3_sim/urdf/gz_waffle.sdf.xacro
+++ b/nav2_minimal_tb3_sim/urdf/gz_waffle.sdf.xacro
@@ -299,7 +299,7 @@
         <collision name='collision'>
           <geometry>
             <sphere>
-              <radius>0.005000</radius>
+              <radius>0.006000</radius>
             </sphere>
           </geometry>
           <surface>
@@ -333,7 +333,7 @@
         <collision name='collision'>
           <geometry>
             <sphere>
-              <radius>0.005000</radius>
+              <radius>0.006000</radius>
             </sphere>
           </geometry>
           <surface>


### PR DESCRIPTION
The issue seems to be in collision tag of caster wheels.Originally they are set to 
```
<sphere>
              <radius>0.005000</radius>
</sphere>
```
but with this the robot is tilted backwords and causes issues like https://github.com/gazebosim/gz-sensors/issues/509#issue-2940806702 this.Correcting the value to 
```
<sphere>
              <radius>0.006000</radius>
</sphere>
```
seems to solve the issue and it behaves as expected.Havent yet being able to identify why this happens , but i guess it something related to the meshes and scaling.