### PR TITLE
Fixed imu joint missing

### DIFF
--- a/nav2_minimal_tb3_sim/package.xml
+++ b/nav2_minimal_tb3_sim/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nav2_minimal_tb3_sim</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>Nav2 Minimum TurtleBot3 Simulation</description>
   <maintainer email="steve@opennav.org">Steve Macenski</maintainer>
   <license>Apache 2.0</license>

--- a/nav2_minimal_tb3_sim/package.xml
+++ b/nav2_minimal_tb3_sim/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nav2_minimal_tb3_sim</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>Nav2 Minimum TurtleBot3 Simulation</description>
   <maintainer email="steve@opennav.org">Steve Macenski</maintainer>
   <license>Apache 2.0</license>

--- a/nav2_minimal_tb3_sim/urdf/gz_waffle.sdf.xacro
+++ b/nav2_minimal_tb3_sim/urdf/gz_waffle.sdf.xacro
@@ -455,6 +455,12 @@
         </axis>
       </joint>
 
+      <joint name="imu_joint" type="fixed">
+        <parent>base_link</parent>
+        <child>imu_link</child>
+        <pose>0.0 0 0.068 0 0 0</pose>
+      </joint>
+
 
       <plugin
         filename="gz-sim-diff-drive-system"

--- a/nav2_minimal_tb3_sim/urdf/gz_waffle.sdf.xacro
+++ b/nav2_minimal_tb3_sim/urdf/gz_waffle.sdf.xacro
@@ -9,7 +9,7 @@
 
       <link name="base_link">
 
-        <inertial>
+        <inertial> 
           <pose>-0.064 0 0.048 0 0 0</pose>
           <inertia>
             <ixx>0.001</ixx>
@@ -299,7 +299,7 @@
         <collision name='collision'>
           <geometry>
             <sphere>
-              <radius>0.005000</radius>
+              <radius>0.006000</radius>
             </sphere>
           </geometry>
           <surface>
@@ -333,7 +333,7 @@
         <collision name='collision'>
           <geometry>
             <sphere>
-              <radius>0.005000</radius>
+              <radius>0.006000</radius>
             </sphere>
           </geometry>
           <surface>

--- a/nav2_minimal_tb3_sim/urdf/turtlebot3_waffle.urdf
+++ b/nav2_minimal_tb3_sim/urdf/turtlebot3_waffle.urdf
@@ -60,7 +60,7 @@
     <visual>
       <origin xyz="-0.064 0 0.0" rpy="0 0 0"/>
       <geometry>
-        <mesh filename="package://nav2_minimal_tb3_sim/models/waffle_base.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/waffle_base.dae" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="light_black"/>
     </visual>
@@ -92,7 +92,7 @@
     <visual>
       <origin xyz="0 0 0" rpy="1.57 0 0"/>
       <geometry>
-        <mesh filename="package://nav2_minimal_tb3_sim/models/tire.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/tire.dae" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="dark"/>
     </visual>
@@ -124,7 +124,7 @@
     <visual>
       <origin xyz="0 0 0" rpy="1.57 0 0"/>
       <geometry>
-        <mesh filename="package://nav2_minimal_tb3_sim/models/tire.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/tire.dae" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="dark"/>
     </visual>
@@ -209,7 +209,7 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
-        <mesh filename="package://nav2_minimal_tb3_sim/models/lds.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/lds.dae" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="dark"/>
     </visual>
@@ -240,7 +240,7 @@
     <visual>
      <origin xyz="0 0 0" rpy="1.57 0 1.57"/>
       <geometry>
-        <mesh filename="package://nav2_minimal_tb3_sim/models/r200.dae" />
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/r200.dae" />
       </geometry>
     </visual>
     <collision>

--- a/nav2_minimal_tb3_sim/urdf/turtlebot3_waffle_gps.urdf
+++ b/nav2_minimal_tb3_sim/urdf/turtlebot3_waffle_gps.urdf
@@ -60,7 +60,7 @@
     <visual>
       <origin xyz="-0.064 0 0.0" rpy="0 0 0"/>
       <geometry>
-        <mesh filename="package://nav2_minimal_tb3_sim/models/waffle_base.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/waffle_base.dae" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="light_black"/>
     </visual>
@@ -92,7 +92,7 @@
     <visual>
       <origin xyz="0 0 0" rpy="1.57 0 0"/>
       <geometry>
-        <mesh filename="package://nav2_minimal_tb3_sim/models/tire.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/tire.dae" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="dark"/>
     </visual>
@@ -124,7 +124,7 @@
     <visual>
       <origin xyz="0 0 0" rpy="1.57 0 0"/>
       <geometry>
-        <mesh filename="package://nav2_minimal_tb3_sim/models/tire.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/tire.dae" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="dark"/>
     </visual>
@@ -216,7 +216,7 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
-        <mesh filename="package://nav2_minimal_tb3_sim/models/lds.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/lds.dae" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="dark"/>
     </visual>
@@ -247,7 +247,7 @@
     <visual>
      <origin xyz="0 0 0" rpy="1.57 0 1.57"/>
       <geometry>
-        <mesh filename="package://nav2_minimal_tb3_sim/models/r200.dae" />
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/r200.dae" />
       </geometry>
     </visual>
     <collision>

--- a/nav2_minimal_tb4_description/launch/robot_description.launch.py
+++ b/nav2_minimal_tb4_description/launch/robot_description.launch.py
@@ -43,6 +43,8 @@ def generate_launch_description():
     rviz_config_file = PathJoinSubstitution([pkg_turtlebot4_description, 'rviz', 'config.rviz'])
     namespace = LaunchConfiguration('namespace')
 
+    remappings = [('/tf', 'tf'), ('/tf_static', 'tf_static')]
+
     robot_state_publisher = Node(
         package='robot_state_publisher',
         executable='robot_state_publisher',
@@ -53,10 +55,7 @@ def generate_launch_description():
             {'robot_description': Command(['xacro', ' ', xacro_file,
              ' ', 'namespace:=', namespace])},
         ],
-        remappings=[
-            ('/tf', 'tf'),
-            ('/tf_static', 'tf_static')
-        ]
+        remappings=remappings
     )
 
     joint_state_publisher = Node(
@@ -65,10 +64,7 @@ def generate_launch_description():
         name='joint_state_publisher',
         output='screen',
         parameters=[{'use_sim_time': LaunchConfiguration('use_sim_time')}],
-        remappings=[
-            ('/tf', 'tf'),
-            ('/tf_static', 'tf_static')
-        ]
+        remappings=remappings
     )
 
     rviz2 = Node(
@@ -78,10 +74,7 @@ def generate_launch_description():
         output='screen',
         arguments=['-d', rviz_config_file],
         parameters=[{'use_sim_time': LaunchConfiguration('use_sim_time')}],
-        remappings=[
-            ('/tf', 'tf'),
-            ('/tf_static', 'tf_static')
-        ],
+        remappings=remappings,
     )
 
     ld = LaunchDescription(ARGUMENTS)

--- a/nav2_minimal_tb4_description/package.xml
+++ b/nav2_minimal_tb4_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nav2_minimal_tb4_description</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>Nav2's minimum Turtlebot4 Description package</description>
   <maintainer email="steve@opennav.org">Steve Macenski</maintainer>
   <license>Apache 2.0</license>

--- a/nav2_minimal_tb4_description/package.xml
+++ b/nav2_minimal_tb4_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nav2_minimal_tb4_description</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>Nav2's minimum Turtlebot4 Description package</description>
   <maintainer email="steve@opennav.org">Steve Macenski</maintainer>
   <license>Apache 2.0</license>

--- a/nav2_minimal_tb4_sim/launch/simulation.launch.py
+++ b/nav2_minimal_tb4_sim/launch/simulation.launch.py
@@ -151,10 +151,7 @@ def generate_launch_description():
         output='screen',
         arguments=['-d', rviz_config_file],
         parameters=[{'use_sim_time': use_sim_time}],
-        remappings=[
-            ('/tf', 'tf'),
-            ('/tf_static', 'tf_static')
-        ],
+        remappings=remappings,
     )
 
     # The SDF file for the world is a xacro file because we wanted to

--- a/nav2_minimal_tb4_sim/package.xml
+++ b/nav2_minimal_tb4_sim/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nav2_minimal_tb4_sim</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>Nav2 Minimum TurtleBot4 Simulation</description>
   <maintainer email="steve@opennav.org">Steve Macenski</maintainer>
   <license>Apache 2.0</license>

--- a/nav2_minimal_tb4_sim/package.xml
+++ b/nav2_minimal_tb4_sim/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nav2_minimal_tb4_sim</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>Nav2 Minimum TurtleBot4 Simulation</description>
   <maintainer email="steve@opennav.org">Steve Macenski</maintainer>
   <license>Apache 2.0</license>


### PR DESCRIPTION
Hello!

While testing the EKF with the simulation, I noticed that the IMU sensor data was behaving abnormally. Upon closer inspection, I found that in Gazebo, the IMU was **falling infinitely**.

![스크린샷 2025-05-27 오전 12 27 44](https://github.com/user-attachments/assets/12eb6a01-eeb6-4dee-bf5e-153e7586c141)

After checking the model, I discovered that the `imu_joint` was missing in the `gz_waffle.sdf.xacro` file. 

To fix this, I added a fixed joint between `base_link` and `imu_link`:

```xml
      <joint name="imu_joint" type="fixed">
        <parent>base_link</parent>
        <child>imu_link</child>
        <pose>0.0 0 0.068 0 0 0</pose>
      </joint>
```

After applying this fix, the IMU remains correctly attached to the robot, and the EKF output is stable.

![스크린샷 2025-05-27 오후 8 48 25](https://github.com/user-attachments/assets/8191783d-8564-472f-8921-92a6a8b6d1bc)

Please let me know if any adjustments are needed. Thank you!