### PR TITLE
Fixed imu joint missing (for jazzy)

### DIFF
--- a/nav2_minimal_tb3_sim/urdf/gz_waffle.sdf.xacro
+++ b/nav2_minimal_tb3_sim/urdf/gz_waffle.sdf.xacro
@@ -455,6 +455,12 @@
         </axis>
       </joint>
 
+      <joint name="imu_joint" type="fixed">
+        <parent>base_link</parent>
+        <child>imu_link</child>
+        <pose>0.0 0 0.068 0 0 0</pose>
+      </joint>
+
 
       <plugin
         filename="gz-sim-diff-drive-system"


### PR DESCRIPTION
Hello!

While testing the EKF with the simulation, I noticed that the IMU sensor data was behaving abnormally. Upon closer inspection, I found that in Gazebo, the IMU was **falling infinitely**.

![스크린샷 2025-05-27 오전 12 27 44](https://github.com/user-attachments/assets/12eb6a01-eeb6-4dee-bf5e-153e7586c141)

After checking the model, I discovered that the `imu_joint` was missing in the `gz_waffle.sdf.xacro` file. 

To fix this, I added a fixed joint between `base_link` and `imu_link`:

```xml
      <joint name="imu_joint" type="fixed">
        <parent>base_link</parent>
        <child>imu_link</child>
        <pose>0.0 0 0.068 0 0 0</pose>
      </joint>
```

After applying this fix, the IMU remains correctly attached to the robot, and the EKF output is stable.

![스크린샷 2025-05-27 오후 8 48 25](https://github.com/user-attachments/assets/8191783d-8564-472f-8921-92a6a8b6d1bc)

Please let me know if any adjustments are needed. Thank you!